### PR TITLE
Add ORI Plugin Registry feature tile

### DIFF
--- a/data/features/plugin-registry.yaml
+++ b/data/features/plugin-registry.yaml
@@ -1,0 +1,5 @@
+weight: 7
+name: "ORI Plugin Registry"
+icon: "fas fa-plug"
+url: "https://academysoftwarefoundation.github.io/ori-shared-platform-website/"
+description: "A discovery portal for community created plugins designed to extend Open Review Initiative media playback applications."


### PR DESCRIPTION
Adds a seventh feature tile linking to the [ORI Plugin Registry](https://academysoftwarefoundation.github.io/ori-shared-platform-website/), a discovery portal for community-created plugins that extend ORI media playback applications.

Verified locally with Hugo 0.147.8: the tile renders with the `fa-plug` icon and correct link, and the registry URL returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)