### PR TITLE
Lay out feature tiles as 4+3 instead of 6+1

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -116,7 +116,7 @@ pluralizelisttitles = false
 
 [params.features]
     enable = true
-    cols = 6
+    cols = 4
 
 [params.video]
     enable = true


### PR DESCRIPTION
With seven feature tiles, the previous `cols = 6` setting left the new ORI Plugin Registry tile orphaned on its own row. Setting `cols = 4` produces a balanced 4+3 layout with roomier tiles.

Verified locally with Hugo 0.147.8: row one renders OpenRV / X-studio / Encoding Guidelines / RPA, row two renders Synchronization protocol / Annotation Exchange Specification / ORI Plugin Registry, each at `col-md-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)