### PR TITLE
Rename registry tile to ORI Plug-in Registry; update X-studio icon

### DIFF
--- a/data/features/plugin-registry.yaml
+++ b/data/features/plugin-registry.yaml
@@ -1,5 +1,5 @@
 weight: 7
-name: "ORI Plugin Registry"
+name: "ORI Plug-in Registry"
 icon: "fas fa-plug"
 url: "https://academysoftwarefoundation.github.io/ori-shared-platform-website/"
 description: "A discovery portal for community created plugins designed to extend Open Review Initiative media playback applications."

--- a/data/features/xstudio.yaml
+++ b/data/features/xstudio.yaml
@@ -1,5 +1,5 @@
 weight: 2
 name: "X-studio"
-icon: "fas fa-desktop"
+icon: "fas fa-plug"
 url: "https://github.com/AcademySoftwareFoundation/xstudio"
 description: "Modern media review and collaboration platform designed for today's distributed workflows. Cloud-native architecture with real-time collaboration and advanced annotation tools."


### PR DESCRIPTION
Two small feature-tile tweaks:

- Rename "ORI Plugin Registry" to "ORI Plug-in Registry"
- Change the X-studio tile icon from `fa-desktop` to `fa-plug`

Note: X-studio now shares the `fa-plug` icon with the Plug-in Registry tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)